### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Welcome to the Tinybird Agent Skills project! 🐦
 ## Quick Links
 - **GitHub:** https://github.com/tinybirdco/tinybird-agent-skills
 - **Slack Community:** https://www.tinybird.co/community
-- **X/Twitter:** [@tinaborbird](https://x.com/tinaborbird)
+- **X/Twitter:** [@tinybird](https://x.com/tinybird)
 - **Documentation:** https://www.tinybird.co/docs
 
 ## How to Contribute

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Tinybird Agent Skills
+
+Welcome to the Tinybird Agent Skills project! 🐦
+
+## Quick Links
+- **GitHub:** https://github.com/tinybirdco/tinybird-agent-skills
+- **Slack Community:** https://www.tinybird.co/community
+- **X/Twitter:** [@tinaborbird](https://x.com/tinaborbird)
+- **Documentation:** https://www.tinybird.co/docs
+
+## How to Contribute
+1. **Bugs & small fixes** → Open a PR!
+2. **New features / architecture** → Start a [GitHub Discussion](https://github.com/tinybirdco/tinybird-agent-skills/discussions) or ask in Slack first
+3. **Questions** → Slack community
+
+## Before You PR
+- Test locally
+- Keep PRs focused (one thing per PR)
+- Describe what & why
+
+## AI/Vibe-Coded PRs Welcome! 🤖
+
+Built with Codex, Claude, or other AI tools? **Awesome - just mark it!**
+
+Please include in your PR:
+- [ ] Mark as AI-assisted in the PR title or description
+- [ ] Note the degree of testing (untested / lightly tested / fully tested)
+- [ ] Include prompts or session logs if possible (super helpful!)
+- [ ] Confirm you understand what the code does
+
+AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for.


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md with guidelines for contributors
- Includes links to Tinybird Slack community, Twitter, and docs
- Welcomes AI-assisted contributions with transparency guidelines

Based on [clawdbot's CONTRIBUTING.md](https://github.com/clawdbot/clawdbot/blob/main/CONTRIBUTING.md), adapted for Tinybird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)