### PR TITLE
fix(tinybird): replace placeholder URL flagged as malicious

### DIFF
--- a/skills/tinybird-cli-guidelines/rules/append-data.md
+++ b/skills/tinybird-cli-guidelines/rules/append-data.md
@@ -9,7 +9,7 @@ tb datasource append [datasource_name] --file /path/to/local/file
 ```
 
 ```
-tb datasource append [datasource_name] --url https://url_to_csv
+tb datasource append [datasource_name] --url https://example.com/data.csv
 ```
 
 ```


### PR DESCRIPTION
## Summary
- replace placeholder URL `https://url_to_csv` with canonical safe example `https://example.com/data.csv`
- keep CLI usage intent unchanged while avoiding security scanner false positives

## Why
The skills.sh Agent Trust Hub audit marked the `tinybird` skill as `Fail` / `CRITICAL` because it detected one malicious URL. This update removes the non-canonical placeholder URL likely triggering that finding.

## Validation
- verified file now contains `https://example.com/data.csv`
- no other changes in this PR
